### PR TITLE
Proposal: Web Worker API

### DIFF
--- a/libs/rxjs-web/src/lib/web-worker/web-worker.spec.ts
+++ b/libs/rxjs-web/src/lib/web-worker/web-worker.spec.ts
@@ -3,9 +3,10 @@ import { observeWebWorker } from './web-worker';
 
 describe('observeWebWorker', () => {
   it('should support posting a message via string worker', done => {
-    const postMessage = new Subject<any>();
 
-    observeWebWorker('./worker.js', postMessage).subscribe(response => {
+    const [worker, postMessage] = observeWebWorker('./worker.js')
+
+    worker.subscribe(response => {
       expect(response).toBe('THIS IS A TEST');
       done();
     });
@@ -14,12 +15,13 @@ describe('observeWebWorker', () => {
   });
 
   it('should support posting a message via passed worker', done => {
-    const worker = new Worker('./worker.js');
-    observeWebWorker(worker).subscribe(response => {
+    const outerWorker = new Worker('./worker.js');
+    const [worker, postMessage] = observeWebWorker(outerWorker)
+    worker.subscribe(response => {
       expect(response).toBe('THIS IS A TEST');
       done();
     });
 
-    worker.postMessage('this is a test');
+    postMessage.next('this is a test');
   });
 });

--- a/libs/rxjs-web/src/lib/web-worker/web-worker.spec.ts
+++ b/libs/rxjs-web/src/lib/web-worker/web-worker.spec.ts
@@ -1,0 +1,18 @@
+import { observeWebWorker } from './web-worker';
+
+describe('observeWebWorker', () => {
+  let worker: Worker;
+
+  beforeEach(() => {
+    worker = new Worker('./worker.js');
+  });
+
+  it('should support posting a message via passed worker', done => {
+    observeWebWorker(worker).subscribe(response => {
+      expect(response).toBe('THIS IS A TEST');
+      done();
+    });
+
+    worker.postMessage('this is a test');
+  });
+});

--- a/libs/rxjs-web/src/lib/web-worker/web-worker.spec.ts
+++ b/libs/rxjs-web/src/lib/web-worker/web-worker.spec.ts
@@ -1,13 +1,20 @@
+import { Subject } from 'rxjs';
 import { observeWebWorker } from './web-worker';
 
 describe('observeWebWorker', () => {
-  let worker: Worker;
+  it('should support posting a message via string worker', done => {
+    const postMessage = new Subject<any>();
 
-  beforeEach(() => {
-    worker = new Worker('./worker.js');
+    observeWebWorker('./worker.js', postMessage).subscribe(response => {
+      expect(response).toBe('THIS IS A TEST');
+      done();
+    });
+
+    postMessage.next('this is a test');
   });
 
   it('should support posting a message via passed worker', done => {
+    const worker = new Worker('./worker.js');
     observeWebWorker(worker).subscribe(response => {
       expect(response).toBe('THIS IS A TEST');
       done();

--- a/libs/rxjs-web/src/lib/web-worker/web-worker.ts
+++ b/libs/rxjs-web/src/lib/web-worker/web-worker.ts
@@ -1,20 +1,36 @@
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 
 /**
  * Provide an observable web worker
  * @param worker
  * @param postMessage
  */
-export function observeWebWorker(worker: Worker) {
+export function observeWebWorker(
+  worker: Worker | string,
+  postMessage?: Observable<any>
+): Observable<MessageEvent> {
+  let subscription: Subscription;
+  const innerWorker = typeof worker === 'string' ? new Worker(worker) : worker;
+
   return new Observable(subscriber => {
-    worker.onmessage = function(message) {
+    innerWorker.onmessage = function(message) {
       subscriber.next(message);
     };
 
-    worker.onerror = function(error) {
+    innerWorker.onerror = function(error) {
       subscriber.error(error);
     };
+    if (postMessage) {
+      subscription = postMessage.subscribe(message =>
+        innerWorker.postMessage(message)
+      );
+    }
 
-    return () => worker.terminate();
+    return () => {
+      if (subscription) {
+        subscription.unsubscribe();
+      }
+      innerWorker.terminate();
+    };
   });
 }

--- a/libs/rxjs-web/src/lib/web-worker/web-worker.ts
+++ b/libs/rxjs-web/src/lib/web-worker/web-worker.ts
@@ -1,0 +1,20 @@
+import { Observable } from 'rxjs';
+
+/**
+ * Provide an observable web worker
+ * @param worker
+ * @param postMessage
+ */
+export function observeWebWorker(worker: Worker) {
+  return new Observable(subscriber => {
+    worker.onmessage = function(message) {
+      subscriber.next(message);
+    };
+
+    worker.onerror = function(error) {
+      subscriber.error(error);
+    };
+
+    return () => worker.terminate();
+  });
+}

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -21,6 +21,18 @@ class MockPerformanceObserver {
   observe() {}
 }
 
+class MockWorker {
+  constructor(public path: string) {}
+
+  postMessage(message: string, options?: Transferable[]) {
+    this.onmessage(message.toUpperCase());
+  }
+
+  onmessage(response: string) {}
+
+  onerror() {}
+}
+
 Object.assign(global, { document: dom.window.document });
 Object.assign(global, { window: dom.window });
 Object.assign(global, {
@@ -44,4 +56,8 @@ Object.assign(global, {
   MutationObserver: GenericObserver,
   ResizeObserver: GenericObserver,
   PerformanceObserver: MockPerformanceObserver
+});
+
+Object.assign(global, {
+  Worker: MockWorker
 });


### PR DESCRIPTION
This PR provides one possible solution to wrapping the [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker) API.

The `observeWebWorker` supports passing in a `Worker` and wraps it's `onmessage` and `onerror` methods as output to the subscription.  In this way the user has to create the web worker but has full access to it.

The second way is to support passing just a string for the path and letting the method create the worker.  In this case the worker is not exposed so a way needs to be used to call `postMessage`

This way can be achieved by passing a Subject in (probably a BehaviourSubject or ReplaySubject for multiple message).

On the method end call it cleans up any subscription it may have, it also terminates the worker.