### PR TITLE
feat(speech): add listen and speak creation operators

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@
 
 /dist
 /coverage
+
+*.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,6 @@
 	"printWidth": 120,
 	"useTabs": true,
 	"semi": true,
-	"trailingComma": "es5"
+	"trailingComma": "es5",
+  "arrowParens": "avoid"
 }

--- a/libs/rxjs-web/src/index.ts
+++ b/libs/rxjs-web/src/index.ts
@@ -1,9 +1,10 @@
 // Observer API
-export { fromMutationObserver, MutationNotification } from './lib/observer/mutationObserver';
-export { fromResizeObserver, ResizeNotification } from './lib/observer/resizeObserver';
-export { fromPerformanceObserver, PerformanceNotification } from './lib/observer/performanceObserver';
 export { fromIntersectionObserver, IntersectionNotification } from './lib/observer/intersectionObserver';
-
+export { fromMutationObserver, MutationNotification } from './lib/observer/mutationObserver';
+export { fromPerformanceObserver, PerformanceNotification } from './lib/observer/performanceObserver';
+export { fromResizeObserver, ResizeNotification } from './lib/observer/resizeObserver';
+// util types
+export { NotSupportedException } from './lib/types/support.exception';
 // Dynamic Import API
 export { fromImport } from './lib/web-api/fromImport';
 // MediaListQuery API
@@ -16,6 +17,5 @@ export { fromPermission } from './lib/web-api/fromPermission';
 export { fromPosition } from './lib/web-api/fromPosition';
 // Sensor API
 export { fromSensor } from './lib/web-api/fromSensor';
-
-// util types
-export { NotSupportedException } from './lib/types/support.exception';
+// Web Speech API
+export { listen, speak } from './lib/web-api/SpeechAPI';

--- a/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechRecognition/README.md
+++ b/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechRecognition/README.md
@@ -1,0 +1,27 @@
+<div align="center">
+  <h1>
+    <br/>
+    👂
+    <br/>
+    <sub><sub>Web API Speech recognition with RxJS</sub></sub>
+    <br/>
+    <br/>
+  </h1>
+</div>
+
+A RxJS wrapper of browser native [SpeechRecognition](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition)
+
+## Use
+
+```js
+import { listen } from 'rxjs-web';
+
+listen({ lang: 'en' })
+  .subscribe(e => {
+    if (e.type == 'result') {
+      console.log(e.results[0][0].transcript);
+    }
+  });
+```
+
+## Enjoy 🙂

--- a/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechRecognition/gapi.ts
+++ b/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechRecognition/gapi.ts
@@ -1,0 +1,15 @@
+// Global API
+// use webkit API on webkit
+
+const _SpeechRecognition: typeof SpeechRecognition =
+	globalThis.SpeechRecognition || (globalThis as any)['webkitSpeechRecognition'];
+const _SpeechGrammarList: typeof SpeechGrammarList =
+	globalThis.SpeechGrammarList || (globalThis as any)['webkitSpeechGrammarList'];
+const _SpeechRecognitionEvent: typeof SpeechRecognitionEvent =
+	globalThis.SpeechRecognitionEvent || (globalThis as any)['webkitSpeechRecognitionEvent'];
+
+export {
+	_SpeechRecognition as SpeechRecognition,
+	_SpeechGrammarList as SpeechGrammarList,
+	_SpeechRecognitionEvent as SpeechRecognitionEvent,
+};

--- a/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechRecognition/index.ts
+++ b/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechRecognition/index.ts
@@ -1,0 +1,2 @@
+export * from './gapi';
+export * from './listen';

--- a/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechRecognition/listen.ts
+++ b/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechRecognition/listen.ts
@@ -1,0 +1,92 @@
+import { fromEvent, merge, Observable, Observer, throwError } from 'rxjs';
+import { delay, mergeMap, takeUntil } from 'rxjs/operators';
+import { SpeechRecognition } from './gapi';
+
+export interface SpeechRecognitionConfig {
+	grammars?: SpeechGrammarList;
+	continuous?: boolean;
+	lang?: string;
+	interimResults?: boolean;
+	maxAlternatives?: number;
+	serviceURI?: string;
+}
+
+const optionsKeys: (keyof SpeechRecognitionConfig)[] = [
+	'grammars',
+	'continuous',
+	'lang',
+	'interimResults',
+	'maxAlternatives',
+	'serviceURI',
+];
+
+export function listen(value: SpeechRecognition | SpeechRecognitionConfig = {}) {
+	return new Observable((observer: Observer<Event | SpeechRecognitionEvent>) => {
+		let recognition: SpeechRecognition;
+
+		if (value instanceof SpeechRecognition) {
+			recognition = value;
+		} else {
+			recognition = new SpeechRecognition();
+
+			optionsKeys.forEach(key => {
+				if (key in value) {
+					// have to suppress TS as it complains that SpeechRecognition
+					// can't be assigned values from SpeechRecognitionConfig
+					(recognition as any)[key] = value[key];
+				}
+			});
+		}
+
+		// error -- as errors on Observable
+		const error$: Observable<Event> = fromEvent(recognition, 'error').pipe(mergeMap(event => throwError(event)));
+
+		// listen to results
+		const nomatch$ = fromEvent(recognition, 'nomatch') as Observable<SpeechRecognitionEvent>;
+		const result$ = fromEvent(recognition, 'result') as Observable<SpeechRecognitionEvent>;
+
+		// audio, sound and speech recognition marks
+		const audiostart$ = fromEvent(recognition, 'audiostart');
+		const audioend$ = fromEvent(recognition, 'audioend');
+		const soundstart$ = fromEvent(recognition, 'soundstart');
+		const soundend$ = fromEvent(recognition, 'soundend');
+		const speechstart$ = fromEvent(recognition, 'speechstart');
+		const speechend$ = fromEvent(recognition, 'speechend');
+
+		// end -- completes Observable
+		const end$ = fromEvent(recognition, 'end');
+
+		// start listening to events
+		const subscription = merge(
+			audiostart$,
+			audioend$,
+			soundstart$,
+			soundend$,
+			speechstart$,
+			speechend$,
+			nomatch$,
+			result$,
+			error$
+		)
+			.pipe(
+				takeUntil(
+					// delay fix for FF:
+					// it seem to fire 'end' event BEFORE the 'result'
+					// (tested on: 78.0.2 (64-bit) MacOS, w/ recognise.enabled + force_enabled)
+					end$.pipe(delay(1))
+				)
+			)
+			.subscribe(observer);
+
+		recognition.start();
+
+		// NOTE: not sure if to use abort() or stop() here
+		// TODO: triage more
+		subscription.add(() => recognition.abort());
+
+		return subscription;
+	});
+
+	// TODO: consider using share() for the result since there would always be
+	// only one running instance at a given time
+}

--- a/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechSynthesis/README.md
+++ b/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechSynthesis/README.md
@@ -1,0 +1,66 @@
+<div align="center">
+  <h1>
+    <br/>
+    🗣
+    <br/>
+    <sub><sub>Web API Text-to-Speech with RxJS</sub></sub>
+    <br/>
+    <br/>
+  </h1>
+</div>
+
+A RxJS wrapper of browser native [SpeechSynthesis](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis)
+
+It provides handy interface for chaining and aborting Text to Speech.
+
+## Usage
+
+```js
+import { speak } from 'rxjs-web';
+
+speak('Hello!').subscribe();
+```
+
+## Chained
+
+```js
+import { speak } from 'rxjs-web';
+
+concat(
+    speak('Hello, mom!'),
+    speak('How are you?'),
+    speak('I miss you.'),
+).subscribe();
+```
+
+## Advanced usage
+
+```js
+import { of, merge, concat, timer } from 'rxjs';
+import { map, takeUntil } from 'rxjs/operators';
+import { speak, SpeechSynthesisUtteranceConfig } from 'rxjs-web';
+
+const a: string = 'Hello, mom!';
+
+const b: SpeechSynthesisUtteranceConfig = {
+  text: 'How are you?',
+  lang: 'en-UK',
+  pitch: 1,
+  rate: 1,
+  volume: 1,
+};
+
+const c = new SpeechSynthesisUtterance('I miss you');
+c.rate = 1;
+c.lang = 'en-US';
+c.pitch = 1;
+c.rate = 1;
+c.volume = 1;
+
+concat(speak(a), speak(b), speak(c)).subscribe((e: SpeechSynthesisEvent) => {
+  console.log(e.name);
+  console.log(e.type);
+});
+```
+
+## Enjoy 🙂

--- a/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechSynthesis/index.ts
+++ b/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechSynthesis/index.ts
@@ -1,0 +1,1 @@
+export * from './speak';

--- a/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechSynthesis/speak.ts
+++ b/libs/rxjs-web/src/lib/web-api/SpeechAPI/SpeechSynthesis/speak.ts
@@ -1,0 +1,73 @@
+import { fromEvent, merge, Observable, throwError, timer } from 'rxjs';
+import { switchMap, switchMapTo, takeUntil } from 'rxjs/operators';
+
+export interface SpeechSynthesisUtteranceConfig {
+	text: string;
+	volume?: number;
+	rate?: number;
+	pitch?: number;
+	lang?: string;
+	voice?: SpeechSynthesisVoice;
+}
+
+const optionsKeys: (keyof SpeechSynthesisUtteranceConfig)[] = ['text', 'voice', 'volume', 'rate', 'pitch', 'lang'];
+
+export function speak(value: string | SpeechSynthesisUtteranceConfig | SpeechSynthesisUtterance) {
+	const voice$ = new Observable(observer => {
+		let utterance: SpeechSynthesisUtterance;
+		if (typeof value == 'string') {
+			utterance = new SpeechSynthesisUtterance(value);
+		} else if (value instanceof SpeechSynthesisUtterance) {
+			utterance = value;
+		} else if (value && typeof value.text == 'string') {
+			utterance = new SpeechSynthesisUtterance();
+			optionsKeys.forEach(key => {
+				if (key in value) {
+					// ts complains that utterance[key] is `never`
+					(utterance[key] as any) = value[key];
+				}
+			});
+		} else {
+			observer.error(
+				new Error(
+					'Unrecognized input: pass string | SpeechSynthesisUtteranceConfig | SpeechSynthesisUtterance to speak(...) function.'
+				)
+			);
+			observer.complete(); // < not sure if this is needed
+			return;
+		}
+
+		// subscibe to Utterance events
+		const boundary$ = fromEvent(utterance, 'boundary');
+		const mark$ = fromEvent(utterance, 'mark');
+		const pause$ = fromEvent(utterance, 'pause');
+		const resume$ = fromEvent(utterance, 'resume');
+		const start$ = fromEvent(utterance, 'start');
+		// error -- as errors on Observable
+		const error$ = fromEvent(utterance, 'error').pipe(switchMap(e => throwError(e)));
+		// end -- completes Observable
+		const end$ = fromEvent(utterance, 'end');
+
+		const subscription = merge(boundary$, mark$, pause$, resume$, start$, error$)
+			.pipe(takeUntil(end$))
+			.subscribe(observer);
+
+		speechSynthesis.speak(utterance);
+		speechSynthesis.resume();
+
+		// cancel all utterances on unsubscribe
+		// this is needed for cancelation flow
+		// theres no other way to stop tts now
+		subscription.add(() => {
+			speechSynthesis.cancel();
+		});
+
+		return subscription;
+	});
+
+	// make a pause to let speechSynthesis.cancel pass
+	return timer(4).pipe(switchMapTo(voice$));
+
+	// TODO: consider using share() for result since there would always be only
+	// one running instance at a given time
+}

--- a/libs/rxjs-web/src/lib/web-api/SpeechAPI/index.ts
+++ b/libs/rxjs-web/src/lib/web-api/SpeechAPI/index.ts
@@ -1,0 +1,2 @@
+export * from './SpeechRecognition';
+export * from './SpeechSynthesis';


### PR DESCRIPTION
Hey! 👋

This is a migration of [rxjs-tts](https://github.com/kosich/rxjs-tts) and [rxjs-stt](https://github.com/kosich/rxjs-stt) libraries

This PR adds support for [Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API):

- `fromSpeechRecognition` creation operator that wraps [SpeechRecognition](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition)
  _originally this method was called `listen`_

- and `speak` creation operator that wraps [SpeechSynthesis](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis)
  _couldn't come up with a better name: `fromSpeechSynthesis` doesn't sound exactly right since it's rather a generation, not subscribing for events_

Both have dedicated README-s with basic API examples. I suggest either including those in the root README, or linking child readmes from the root.

Please, review 🙂
Thanks